### PR TITLE
Enable Windows Inference Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ conda activate partcrafter
 pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu124
 ```
 Then, install other dependencies with the following command:
-```
+
+```bash
 git clone https://github.com/wgsxm/PartCrafter.git
 cd PartCrafter
-bash settings/setup.sh
+bash settings/setup.sh # for Linux
+# OR
+./settings/setup.bat # for Windows
 ```
 If you do not have root access and use conda environment, you can install required graphics libraries with the following command:
 ```

--- a/settings/requirements-inference.txt
+++ b/settings/requirements-inference.txt
@@ -1,0 +1,21 @@
+scikit-learn
+gpustat
+nvitop
+diffusers
+transformers
+einops
+huggingface_hub
+opencv-python
+trimesh
+omegaconf
+scikit-image
+numpy==1.26.4
+peft
+jaxtyping
+typeguard
+matplotlib
+imageio-ffmpeg
+pyrender
+# deepspeed (uncomment due to unable to compile on windows, this is only needed for training `train_partcrafter.py`)
+wandb[media]
+colormaps

--- a/settings/setup.bat
+++ b/settings/setup.bat
@@ -1,0 +1,2 @@
+CALL pip install torch-cluster -f https://data.pyg.org/whl/torch-2.5.1+cu124.html
+CALL pip install -r settings/requirements-inference.txt

--- a/src/utils/render_utils.py
+++ b/src/utils/render_utils.py
@@ -1,6 +1,7 @@
 from src.utils.typing_utils import *
 
 import os
+import sys
 import numpy as np
 from PIL import Image
 import trimesh
@@ -11,7 +12,11 @@ from diffusers.utils.loading_utils import load_video
 import torch
 from torchvision.utils import make_grid
 
-os.environ['PYOPENGL_PLATFORM'] = 'egl'
+
+# Set PYOPENGL_PLATFORM to 'egl' for Linux
+# Windows users will receive import errors if this is set.
+if sys.platform.startswith("linux"):
+    os.environ["PYOPENGL_PLATFORM"] = "egl"
 
 def render(
     scene: pyrender.Scene,


### PR DESCRIPTION
DeepSpeed compilation fails on Windows, preventing installation. This PR isolates the dependency to enable Windows inference.

## Changes
- Added `requirements-inference.txt`, excluding `deepspeed`.
- Added `setup.bat` that automates environment setup for Windows users using the inference-only requirements.

## Limitations:
- Windows environments are restricted to inference usage.
- `train_partcrafter.py` remains unsupported on Windows due to the missing dependency.

Hope this PR is helpful :)