### PR TITLE
[WIP] Add VLM part suggestion and style transfer for real-world images

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,39 @@ The generated results will be saved to `./results/robot`. We provide several exa
 
 Specify `--rmbg` if you use custom images. **This will remove the background of the input image and resize it appropriately.**
 
+### VLM-Based Part Suggestion
+Instead of manually specifying `--num_parts`, you can use a VLM to automatically suggest the number of parts:
+```
+GEMINI_API_KEY=your_key python scripts/inference_partcrafter.py \
+  --image_path assets/images/np3_2f6ab901c5a84ed6bbdf85a67b22a2ee.png \
+  --part_suggest --tag robot --rmbg --render
+```
+This sends the image to a VLM (default: `gemini-3-flash-preview`) which analyzes the object and suggests an appropriate part count. You can override the provider or model:
+```
+--part_provider gemini --part_model gemini-3-flash-preview
+```
+
+### Style Transfer for Real-World Images
+PartCrafter was trained on rendered images from Objaverse. When using real-world photos, you can apply style transfer to bridge the domain gap:
+```
+GEMINI_API_KEY=your_key python scripts/inference_partcrafter.py \
+  --image_path real_photo.jpg \
+  --num_parts 4 --style_transfer --rmbg --render
+```
+This converts the input photo to an Objaverse-style 3D rendering (default model: `gemini-3.1-flash-image-preview`) before feeding it to the pipeline. The stylized image is saved as `styled_input.png` in the output directory. You can override the provider or model:
+```
+--style_provider gemini --style_model gemini-3.1-flash-image-preview
+```
+
+Both features can be combined:
+```
+GEMINI_API_KEY=your_key python scripts/inference_partcrafter.py \
+  --image_path real_photo.jpg \
+  --part_suggest --style_transfer --rmbg --render
+```
+
+The provider architecture is extensible -- adding a new provider (e.g., OpenAI) requires only a new file in `src/utils/providers/` implementing `suggest_num_parts()` and/or `stylize_for_objaverse()`.
+
 ### 3D Scene Generation
 <p align="center">
     <img width="90%" alt="pipeline", src="./assets/dining_room.gif">
@@ -92,6 +125,8 @@ The required model weights will be automatically downloaded:
 - PartCrafter-Scene model from [wgsxm/PartCrafter-Scene](https://huggingface.co/wgsxm/PartCrafter-Scene) → pretrained_weights/PartCrafter-Scene
 
 The generated results will be saved to `./results/dining_room`. We provide several example images from 3D-Front in `./assets/images_scene`. Their filenames start with recommended number of parts, e.g., `np3` which means 3 parts. You can also try other part count for the same input images. 
+
+The `--part_suggest` and `--style_transfer` flags are also available for scene-level generation.
 
 ## 💻 System Requirements
 A CUDA-enabled GPU with at least 8GB VRAM. You can reduce number of parts or number of tokens to save GPU memory. We set the number of tokens per part to `1024` on object level and `2048` on scene level by default for better quality. 

--- a/scripts/inference_partcrafter.py
+++ b/scripts/inference_partcrafter.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import sys
 from glob import glob
@@ -66,7 +67,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--image_path", type=str, required=True)
-    parser.add_argument("--num_parts", type=int, required=True, help="number of parts to generate")
+    parser.add_argument("--num_parts", type=int, default=None, help="number of parts to generate (optional if --part_suggest is used)")
     parser.add_argument("--output_dir", type=str, default="./results")
     parser.add_argument("--tag", type=str, default=None)
     parser.add_argument("--seed", type=int, default=0)
@@ -77,9 +78,18 @@ if __name__ == "__main__":
     parser.add_argument("--use_flash_decoder", action="store_true")
     parser.add_argument("--rmbg", action="store_true")
     parser.add_argument("--render", action="store_true")
+    parser.add_argument("--part_suggest", action="store_true", help="use VLM to suggest num_parts automatically")
+    parser.add_argument("--style_transfer", action="store_true", help="apply Objaverse-style transfer to input image")
+    parser.add_argument("--part_provider", type=str, default="gemini", help="provider for part suggestion (default: gemini)")
+    parser.add_argument("--part_model", type=str, default=None, help="model name for part suggestion (default: gemini-3-flash-preview)")
+    parser.add_argument("--style_provider", type=str, default="gemini", help="provider for style transfer (default: gemini)")
+    parser.add_argument("--style_model", type=str, default=None, help="model name for style transfer (default: gemini-3.1-flash-image-preview)")
     args = parser.parse_args()
 
-    assert 1 <= args.num_parts <= MAX_NUM_PARTS, f"num_parts must be in [1, {MAX_NUM_PARTS}]"
+    if args.num_parts is not None:
+        assert 1 <= args.num_parts <= MAX_NUM_PARTS, f"num_parts must be in [1, {MAX_NUM_PARTS}]"
+    elif not args.part_suggest:
+        parser.error("Either --num_parts or --part_suggest must be specified.")
 
     # download pretrained weights
     partcrafter_weights_dir = "pretrained_weights/PartCrafter"
@@ -96,11 +106,45 @@ if __name__ == "__main__":
 
     set_seed(args.seed)
 
+    # create export directory early (style transfer saves here)
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
+    if args.tag is None:
+        args.tag = time.strftime("%Y%m%d_%H_%M_%S")
+    export_dir = os.path.join(args.output_dir, args.tag)
+    os.makedirs(export_dir, exist_ok=True)
+
+    image_path = args.image_path
+
+    # style transfer: convert real-world photo to Objaverse-style rendering
+    if args.style_transfer:
+        from src.utils.style_transfer_utils import stylize_for_objaverse
+        styled_path = os.path.join(export_dir, "styled_input.png")
+        try:
+            stylize_for_objaverse(image_path, styled_path, provider=args.style_provider, model_name=args.style_model)
+            image_path = styled_path
+            print(f"Style transfer complete: {styled_path}")
+        except Exception as e:
+            print(f"Warning: Style transfer failed ({e}), using original image.")
+
+    # VLM part suggestion
+    if args.part_suggest:
+        from src.utils.vlm_utils import suggest_num_parts
+        num_parts = suggest_num_parts(
+            image_path, MAX_NUM_PARTS,
+            mode="object",
+            provider=args.part_provider,
+            model_name=args.part_model,
+        )
+        print(f"VLM suggested {num_parts} parts")
+    else:
+        num_parts = args.num_parts
+
     # run inference
     outputs, processed_image = run_triposg(
         pipe,
-        image_input=args.image_path,
-        num_parts=args.num_parts,
+        image_input=image_path,
+        num_parts=num_parts,
         rmbg_net=rmbg_net,
         seed=args.seed,
         num_tokens=args.num_tokens,
@@ -113,20 +157,27 @@ if __name__ == "__main__":
         device=device,
     )
 
-    if not os.path.exists(args.output_dir):
-        os.makedirs(args.output_dir)
-    
-    if args.tag is None:
-        args.tag = time.strftime("%Y%m%d_%H_%M_%S")
-    
-    export_dir = os.path.join(args.output_dir, args.tag)
-    os.makedirs(export_dir, exist_ok=True)
-
     for i, mesh in enumerate(outputs):
         mesh.export(os.path.join(export_dir, f"part_{i:02}.glb"))
-    
+
     merged_mesh = get_colored_mesh_composition(outputs)
     merged_mesh.export(os.path.join(export_dir, "object.glb"))
+
+    # write manifest
+    manifest = {
+        "image_path": args.image_path,
+        "num_parts": num_parts,
+        "style_transferred": args.style_transfer,
+        "vlm_suggested": args.part_suggest,
+        "parts": [
+            {"index": i, "file": f"part_{i:02}.glb"}
+            for i in range(num_parts)
+        ],
+        "composite_file": "object.glb",
+    }
+    with open(os.path.join(export_dir, "manifest.json"), "w") as f:
+        json.dump(manifest, f, indent=2)
+
     print(f"Generated {len(outputs)} parts and saved to {export_dir}")
 
     if args.render:

--- a/scripts/inference_partcrafter_scene.py
+++ b/scripts/inference_partcrafter_scene.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import sys
 from glob import glob
@@ -59,7 +60,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--image_path", type=str, required=True)
-    parser.add_argument("--num_parts", type=int, required=True, help="number of parts to generate")
+    parser.add_argument("--num_parts", type=int, default=None, help="number of parts to generate (optional if --part_suggest is used)")
     parser.add_argument("--output_dir", type=str, default="./results")
     parser.add_argument("--tag", type=str, default=None)
     parser.add_argument("--seed", type=int, default=0)
@@ -69,9 +70,18 @@ if __name__ == "__main__":
     parser.add_argument("--max_num_expanded_coords", type=int, default=1e9)
     parser.add_argument("--use_flash_decoder", action="store_true")
     parser.add_argument("--render", action="store_true")
+    parser.add_argument("--part_suggest", action="store_true", help="use VLM to suggest num_parts automatically")
+    parser.add_argument("--style_transfer", action="store_true", help="apply Objaverse-style transfer to input image")
+    parser.add_argument("--part_provider", type=str, default="gemini", help="provider for part suggestion (default: gemini)")
+    parser.add_argument("--part_model", type=str, default=None, help="model name for part suggestion (default: gemini-3-flash-preview)")
+    parser.add_argument("--style_provider", type=str, default="gemini", help="provider for style transfer (default: gemini)")
+    parser.add_argument("--style_model", type=str, default=None, help="model name for style transfer (default: gemini-3.1-flash-image-preview)")
     args = parser.parse_args()
 
-    assert 1 <= args.num_parts <= MAX_NUM_PARTS, f"num_parts must be in [1, {MAX_NUM_PARTS}]"
+    if args.num_parts is not None:
+        assert 1 <= args.num_parts <= MAX_NUM_PARTS, f"num_parts must be in [1, {MAX_NUM_PARTS}]"
+    elif not args.part_suggest:
+        parser.error("Either --num_parts or --part_suggest must be specified.")
 
     # download pretrained weights
     partcrafter_weights_dir = "pretrained_weights/PartCrafter-Scene"
@@ -82,11 +92,45 @@ if __name__ == "__main__":
 
     set_seed(args.seed)
 
+    # create export directory early (style transfer saves here)
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
+    if args.tag is None:
+        args.tag = time.strftime("%Y%m%d_%H_%M_%S")
+    export_dir = os.path.join(args.output_dir, args.tag)
+    os.makedirs(export_dir, exist_ok=True)
+
+    image_path = args.image_path
+
+    # style transfer: convert real-world photo to Objaverse-style rendering
+    if args.style_transfer:
+        from src.utils.style_transfer_utils import stylize_for_objaverse
+        styled_path = os.path.join(export_dir, "styled_input.png")
+        try:
+            stylize_for_objaverse(image_path, styled_path, provider=args.style_provider, model_name=args.style_model)
+            image_path = styled_path
+            print(f"Style transfer complete: {styled_path}")
+        except Exception as e:
+            print(f"Warning: Style transfer failed ({e}), using original image.")
+
+    # VLM part suggestion
+    if args.part_suggest:
+        from src.utils.vlm_utils import suggest_num_parts
+        num_parts = suggest_num_parts(
+            image_path, MAX_NUM_PARTS,
+            mode="scene",
+            provider=args.part_provider,
+            model_name=args.part_model,
+        )
+        print(f"VLM suggested {num_parts} parts")
+    else:
+        num_parts = args.num_parts
+
     # run inference
     outputs, processed_image = run_triposg(
         pipe,
-        image_input=args.image_path,
-        num_parts=args.num_parts,
+        image_input=image_path,
+        num_parts=num_parts,
         seed=args.seed,
         num_tokens=args.num_tokens,
         num_inference_steps=args.num_inference_steps,
@@ -97,20 +141,27 @@ if __name__ == "__main__":
         device=device,
     )
 
-    if not os.path.exists(args.output_dir):
-        os.makedirs(args.output_dir)
-    
-    if args.tag is None:
-        args.tag = time.strftime("%Y%m%d_%H_%M_%S")
-    
-    export_dir = os.path.join(args.output_dir, args.tag)
-    os.makedirs(export_dir, exist_ok=True)
-
     for i, mesh in enumerate(outputs):
         mesh.export(os.path.join(export_dir, f"part_{i:02}.glb"))
-    
+
     merged_mesh = get_colored_mesh_composition(outputs)
     merged_mesh.export(os.path.join(export_dir, "object.glb"))
+
+    # write manifest
+    manifest = {
+        "image_path": args.image_path,
+        "num_parts": num_parts,
+        "style_transferred": args.style_transfer,
+        "vlm_suggested": args.part_suggest,
+        "parts": [
+            {"index": i, "file": f"part_{i:02}.glb"}
+            for i in range(num_parts)
+        ],
+        "composite_file": "object.glb",
+    }
+    with open(os.path.join(export_dir, "manifest.json"), "w") as f:
+        json.dump(manifest, f, indent=2)
+
     print(f"Generated {len(outputs)} parts and saved to {export_dir}")
 
     if args.render:

--- a/settings/requirements.txt
+++ b/settings/requirements.txt
@@ -19,3 +19,4 @@ pyrender
 deepspeed
 wandb[media]
 colormaps
+google-genai>=1.0.0

--- a/src/utils/providers/__init__.py
+++ b/src/utils/providers/__init__.py
@@ -1,0 +1,13 @@
+import importlib
+
+PROVIDERS = {
+    "gemini": "src.utils.providers.gemini_provider",
+}
+
+
+def get_provider(name: str):
+    """Lazy-import and return the provider module by name."""
+    if name not in PROVIDERS:
+        available = ", ".join(PROVIDERS.keys())
+        raise ValueError(f"Unknown provider '{name}'. Available: {available}")
+    return importlib.import_module(PROVIDERS[name])

--- a/src/utils/providers/gemini_provider.py
+++ b/src/utils/providers/gemini_provider.py
@@ -1,0 +1,169 @@
+import io
+import json
+import logging
+import os
+import re
+
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VLM_MODEL = "gemini-3-flash-preview"
+DEFAULT_STYLE_MODEL = "gemini-3.1-flash-image-preview"
+
+
+def _get_client():
+    """Initialize the google-genai client using an API key from the environment."""
+    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Gemini API key not found. "
+            "Set the GEMINI_API_KEY or GOOGLE_API_KEY environment variable."
+        )
+    try:
+        from google import genai
+    except ImportError:
+        raise ImportError(
+            "google-genai package is required for the Gemini provider. "
+            "Install it with: pip install google-genai"
+        )
+    return genai.Client(api_key=api_key)
+
+
+def _build_num_parts_prompt(max_num_parts: int, mode: str = "object") -> str:
+    """Build the VLM prompt for suggesting the number of parts."""
+    if mode == "object":
+        return (
+            "You are analyzing an image of a 3D object to determine how many "
+            "structural parts it should be decomposed into for 3D mesh generation.\n\n"
+            "Each part will become a separate 3D mesh. Think about how a 3D modeler "
+            "would segment this object into physically separable, structurally distinct "
+            "components.\n\n"
+            "Guidelines:\n"
+            "- Each part should be a single contiguous solid volume (no disconnected "
+            "floating pieces within one part).\n"
+            "- Symmetric components should be counted individually (e.g., a chair has "
+            "4 separate legs, not 1 group of legs).\n"
+            "- Parts should be non-overlapping and together cover the entire object.\n"
+            f"- The number must be between 1 and {max_num_parts}.\n"
+            "- Fewer large parts is better than many tiny parts -- only split where "
+            "there is a clear structural boundary.\n\n"
+            "Respond ONLY with a single integer representing the number of parts, "
+            "no other text."
+        )
+    else:  # scene mode
+        return (
+            "You are analyzing an image of a 3D indoor scene to determine how many "
+            "distinct objects are present for 3D mesh generation.\n\n"
+            "Each object in the scene will become a separate 3D mesh. Count the "
+            "individual furniture pieces, fixtures, and objects visible in the scene.\n\n"
+            "Guidelines:\n"
+            "- Each item should be a single distinct object (e.g., a table, a lamp, "
+            "a plant).\n"
+            "- Identical items should be counted individually (e.g., 3 chairs = 3, "
+            "not 1).\n"
+            "- Only count clearly visible, substantial objects -- ignore walls, floors, "
+            "and ambient elements.\n"
+            f"- The number must be between 1 and {max_num_parts}.\n\n"
+            "Respond ONLY with a single integer representing the number of objects, "
+            "no other text."
+        )
+
+
+STYLE_TRANSFER_PROMPT = (
+    "Preserve all details of this image and perform style transfer to convert it into "
+    "the visual style of a 3D rendering from the Objaverse dataset.\n\n"
+    "The output should have these characteristics:\n"
+    "- Clean, smooth surfaces with simplified textures\n"
+    "- Soft, even lighting (as if rendered in a 3D engine with basic studio lighting)\n"
+    "- White or very light neutral background\n"
+    "- No real-world imperfections (noise, motion blur, lens distortion, reflections "
+    "of the environment)\n"
+    "- Colors and materials should look like a 3D asset preview render, not a photograph\n"
+    "- Maintain the exact shape, proportions, pose, and all structural details of the "
+    "original object\n\n"
+    "Do NOT change the object itself, its geometry, or add/remove any elements. "
+    "Only change the rendering style to look like a clean 3D model preview."
+)
+
+
+def _parse_int_response(text: str) -> int:
+    """Extract an integer from a VLM response."""
+    text = text.strip()
+    # Try direct int parse first
+    try:
+        return int(text)
+    except ValueError:
+        pass
+    # Look for first integer in the text
+    match = re.search(r"\b(\d+)\b", text)
+    if match:
+        return int(match.group(1))
+    raise ValueError(f"Could not extract an integer from VLM response: {text!r}")
+
+
+def suggest_num_parts(
+    image: Image.Image,
+    max_num_parts: int,
+    mode: str = "object",
+    model_name: str = DEFAULT_VLM_MODEL,
+) -> int:
+    """
+    Use Gemini VLM to suggest how many parts an image should be decomposed into.
+
+    Returns the suggested number of parts (int).
+    """
+    client = _get_client()
+    prompt = _build_num_parts_prompt(max_num_parts, mode=mode)
+
+    response = client.models.generate_content(
+        model=model_name,
+        contents=[image, prompt],
+    )
+
+    try:
+        n = _parse_int_response(response.text)
+    except ValueError:
+        # Retry once
+        logger.warning("First VLM response was not a valid integer, retrying...")
+        response = client.models.generate_content(
+            model=model_name,
+            contents=[image, prompt],
+        )
+        n = _parse_int_response(response.text)
+
+    return max(1, min(n, max_num_parts))
+
+
+def stylize_for_objaverse(
+    image: Image.Image,
+    model_name: str = DEFAULT_STYLE_MODEL,
+) -> Image.Image:
+    """
+    Use Gemini image generation to convert an image to Objaverse-style rendering.
+
+    Returns the stylized PIL Image.
+    """
+    from google import genai
+
+    client = _get_client()
+
+    response = client.models.generate_content(
+        model=model_name,
+        contents=[image, STYLE_TRANSFER_PROMPT],
+        config=genai.types.GenerateContentConfig(
+            response_modalities=["image", "text"],
+        ),
+    )
+
+    # Extract image from response
+    for part in response.candidates[0].content.parts:
+        if hasattr(part, "inline_data") and part.inline_data is not None:
+            mime = part.inline_data.mime_type
+            if mime and mime.startswith("image/"):
+                return Image.open(io.BytesIO(part.inline_data.data))
+
+    raise RuntimeError(
+        "Style transfer failed: no image returned in the Gemini response. "
+        "The model may not have generated an image for this input."
+    )

--- a/src/utils/style_transfer_utils.py
+++ b/src/utils/style_transfer_utils.py
@@ -1,0 +1,39 @@
+import logging
+from typing import Optional
+
+from PIL import Image
+
+from src.utils.providers import get_provider
+
+logger = logging.getLogger(__name__)
+
+
+def stylize_for_objaverse(
+    image_path: str,
+    output_path: str,
+    provider: str = "gemini",
+    model_name: Optional[str] = None,
+) -> Image.Image:
+    """
+    Apply Objaverse-style transfer to an image using the specified provider.
+
+    Args:
+        image_path: Path to the input image.
+        output_path: Path to save the stylized image.
+        provider: Name of the style transfer provider (e.g., "gemini").
+        model_name: Override the provider's default model. None uses the provider default.
+
+    Returns:
+        The stylized PIL Image.
+    """
+    provider_mod = get_provider(provider)
+    image = Image.open(image_path).convert("RGB")
+
+    kwargs = {}
+    if model_name is not None:
+        kwargs["model_name"] = model_name
+
+    result = provider_mod.stylize_for_objaverse(image, **kwargs)
+    result.save(output_path)
+    logger.info(f"Stylized image saved to {output_path}")
+    return result

--- a/src/utils/vlm_utils.py
+++ b/src/utils/vlm_utils.py
@@ -1,0 +1,43 @@
+import logging
+from typing import Optional
+
+from PIL import Image
+
+from src.utils.providers import get_provider
+
+logger = logging.getLogger(__name__)
+
+
+def suggest_num_parts(
+    image_path: str,
+    max_num_parts: int,
+    mode: str = "object",
+    provider: str = "gemini",
+    model_name: Optional[str] = None,
+) -> int:
+    """
+    Use a VLM to analyze an image and suggest how many parts it should be
+    decomposed into.
+
+    Args:
+        image_path: Path to the input image.
+        max_num_parts: Hard upper bound on number of parts.
+        mode: "object" for single-object decomposition, "scene" for multi-object scenes.
+        provider: Name of the VLM provider (e.g., "gemini").
+        model_name: Override the provider's default model. None uses the provider default.
+
+    Returns:
+        The suggested number of parts (clamped to [1, max_num_parts]).
+    """
+    provider_mod = get_provider(provider)
+    image = Image.open(image_path).convert("RGB")
+
+    kwargs = {"mode": mode}
+    if model_name is not None:
+        kwargs["model_name"] = model_name
+
+    n = provider_mod.suggest_num_parts(image, max_num_parts, **kwargs)
+
+    # Clamp to valid range
+    n = max(1, min(int(n), max_num_parts))
+    return n


### PR DESCRIPTION
## Summary
- **VLM-based part suggestion** (`--part_suggest`): Uses a VLM (default: `gemini-3-flash-preview`) to automatically suggest the number of parts for decomposition, replacing the need to manually specify `--num_parts`.
- **Objaverse-style transfer** (`--style_transfer`): Uses an image generation model (default: `gemini-3.1-flash-image-preview`) to convert real-world photos into the Objaverse rendering style, bridging the domain gap between real photos and the training data.
- **Provider-agnostic architecture**: Both features use a pluggable provider system (`src/utils/providers/`). Adding a new backend (e.g., OpenAI) requires only a single new file — no changes to inference scripts.
- Both object-level and scene-level inference scripts updated. Fully backward compatible.

## Motivation
As noted on the [project website](https://wgsxm.github.io/projects/partcrafter), directly testing on real-world images (e.g., from CO3D) leads to suboptimal performance due to domain gap with the Objaverse training data. The authors addressed this by stylizing inputs to resemble 3D renderings. This PR integrates that workflow directly into the pipeline, along with automatic part count suggestion.

## New CLI flags
| Flag | Description |
|------|-------------|
| `--part_suggest` | Use VLM to suggest `num_parts` automatically |
| `--style_transfer` | Apply Objaverse-style transfer to input image |
| `--part_provider` | Provider for part suggestion (default: `gemini`) |
| `--part_model` | Model override for part suggestion |
| `--style_provider` | Provider for style transfer (default: `gemini`) |
| `--style_model` | Model override for style transfer |

## Test plan
- [ ] Backward compat: `python scripts/inference_partcrafter.py --image_path assets/images/np3_*.png --num_parts 3 --rmbg --render`
- [ ] Part suggestion: `GEMINI_API_KEY=xxx python scripts/inference_partcrafter.py --image_path assets/images/np3_*.png --part_suggest --rmbg`
- [ ] Style transfer: `GEMINI_API_KEY=xxx python scripts/inference_partcrafter.py --image_path real_photo.jpg --num_parts 4 --style_transfer --rmbg`
- [ ] Both combined: `GEMINI_API_KEY=xxx python scripts/inference_partcrafter.py --image_path real_photo.jpg --part_suggest --style_transfer --rmbg --render`
- [ ] Scene-level: repeat with `inference_partcrafter_scene.py`
- [ ] Error: omit both `--num_parts` and `--part_suggest` → should error

🤖 Generated with [Claude Code](https://claude.com/claude-code)